### PR TITLE
Newer versions of json.hpp do not include iostream anymore

### DIFF
--- a/src/core/data.cpp
+++ b/src/core/data.cpp
@@ -1,5 +1,6 @@
 #include <tansa/data.h>
 
+#include <iostream>
 #include <cstdlib>
 #include <fstream>
 

--- a/src/jocs/csv.cpp
+++ b/src/jocs/csv.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <algorithm>
-
+#include <iostream>
 
 namespace tansa {
 

--- a/src/model/feasibility.cpp
+++ b/src/model/feasibility.cpp
@@ -2,7 +2,7 @@
 #include <tansa/model.h>
 
 #include <algorithm>
-
+#include <iostream>
 
 /*
 	Need to determine based on a model whether or not a trajectory is possible


### PR DESCRIPTION
Fix compile errors when using newer version

Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>
