### PR TITLE
time: fix conversion

### DIFF
--- a/test/core/time.cpp
+++ b/test/core/time.cpp
@@ -16,7 +16,7 @@ TEST(Time, UnitDurations) {
 	Time diff = Time::now().since(start);
 
 	ASSERT_LT(fabs(0.25 - diff.seconds()), 0.025);
-	ASSERT_LT(abs(udur - diff.micros()), 25000);
+	ASSERT_LT(llabs((int64_t)udur - (int64_t)diff.micros()), 25000);
 }
 
 TEST(Time, scale) {


### PR DESCRIPTION
The intention is to check if the duration is lower than a period.
Convert both params to int64_t.
```
[ 56%] Building CXX object CMakeFiles/test_tansa.dir/test/core/time.cpp.o
In file included from /usr/include/gtest/gtest.h:1929:0,
                 from /home/user/aero-src/tansa/test/core/time.cpp:1:
/home/user/aero-src/tansa/test/core/time.cpp: In member function ‘virtual void Time_UnitDurations_Test::TestBody()’:
/home/user/aero-src/tansa/test/core/time.cpp:19:36: error: call of overloaded ‘abs(uint64_t)’ is ambiguous
  ASSERT_LT(abs(udur - diff.micros()), 25000);
                                    ^
In file included from /usr/include/c++/7/cstdlib:75:0,
                 from /usr/include/c++/7/ext/string_conversions.h:41,
                 from /usr/include/c++/7/bits/basic_string.h:6159,
                 from /usr/include/c++/7/string:52,
                 from /usr/include/c++/7/bits/locale_classes.h:40,
                 from /usr/include/c++/7/bits/ios_base.h:41,
                 from /usr/include/c++/7/ios:42,
                 from /usr/include/c++/7/ostream:38,
                 from /usr/include/gtest/gtest.h:55,
                 from /home/user/aero-src/tansa/test/core/time.cpp:1:
/usr/include/stdlib.h:751:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/7/cstdlib:77:0,
                 from /usr/include/c++/7/ext/string_conversions.h:41,
                 from /usr/include/c++/7/bits/basic_string.h:6159,
                 from /usr/include/c++/7/string:52,
                 from /usr/include/c++/7/bits/locale_classes.h:40,
                 from /usr/include/c++/7/bits/ios_base.h:41,
                 from /usr/include/c++/7/ios:42,
                 from /usr/include/c++/7/ostream:38,
                 from /usr/include/gtest/gtest.h:55,
                 from /home/user/aero-src/tansa/test/core/time.cpp:1:
/usr/include/c++/7/bits/std_abs.h:56:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
/usr/include/c++/7/bits/std_abs.h:61:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/7/bits/std_abs.h:70:3: note: candidate: constexpr double std::abs(double)
   abs(double __x)
   ^~~
/usr/include/c++/7/bits/std_abs.h:74:3: note: candidate: constexpr float std::abs(float)
   abs(float __x)
   ^~~
/usr/include/c++/7/bits/std_abs.h:78:3: note: candidate: constexpr long double std::abs(long double)
   abs(long double __x)
   ^~~
```
Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>